### PR TITLE
Add linebreaks to the rails new command

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ Simplecov, Rubocop and Mutant and can be immediately tested on CircleCI.
 Suggested use:
 
 ```
-rails new -m https://raw.githubusercontent.com/ministryofjustice/moj_rails_template/master/template.rb -d postgresql --skip-spring --skip-turbolinks --skip-test <ProjectName>
+rails new -m https://raw.githubusercontent.com/ministryofjustice/moj_rails_template/master/template.rb \
+          -d postgresql \
+          --skip-spring \
+          --skip-turbolinks \
+          --skip-test <ProjectName>
 ```
 


### PR DESCRIPTION
The command-line flags scroll off the right of the page, and there is a risk that people might miss 
some out. Adding linebreaks keeps the whole command on the page, making it easier to see what's 
going on.
